### PR TITLE
erlang.mk fails to build eep when used as a dependency.

### DIFF
--- a/src/eep.app.src
+++ b/src/eep.app.src
@@ -3,6 +3,7 @@
   {description, "Erlang Easy Profiling (dbg:trace* to kcachegrind)"},
   {vsn, "1.0"},
   {registered, []},
+  {modules, []},
   {applications, [
                   kernel,
                   stdlib


### PR DESCRIPTION
`erlang.mk` (`ERLANG_MK_VERSION = 1`) fails to build `eep` when used as a dependency:

```bash
$ make deps
[...]
ERLC   eep.erl eep_app.erl
Empty modules entry not found in eep.app.src. Please consult the erlang.mk README for instructions.
make[1]: *** [app] Error 1
make: *** [deps] Error 2
```